### PR TITLE
PRODMAG-add-bundle-audit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  gem 'bundle-audit'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,11 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
+    bundle-audit (0.1.0)
+      bundler-audit
+    bundler-audit (0.9.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     byebug (11.1.3)
     cancancan (3.6.1)
     capybara (3.40.0)
@@ -371,6 +376,7 @@ DEPENDENCIES
   activeadmin-searchable_select
   annotate!
   bootsnap
+  bundle-audit
   byebug
   cancancan (~> 3.6)
   capybara

--- a/bin/bundle-audit
+++ b/bin/bundle-audit
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require 'rubygems'
+
+lib_dir = File.expand_path(File.join(File.dirname(__FILE__),'..','lib'))
+$LOAD_PATH << lib_dir unless $LOAD_PATH.include?(lib_dir)
+
+require 'bundler/audit/cli'
+
+Bundler::Audit::CLI.start


### PR DESCRIPTION
### Description

add bundle-audit to add a separate github workflow in future and track the vulnerabilities
per merge requests and by scheduler